### PR TITLE
Avoid referencing global `path` variable

### DIFF
--- a/src/youarei.js
+++ b/src/youarei.js
@@ -98,8 +98,8 @@
         return spl;
       },
 
-      path_to_string: function(opt_path) {
-        path = (opt_path || this._path).join("/");
+      path_to_string: function(path) {
+        path = (path || this._path).join("/");
         if (this._path_leading_slash) path = '/' + path;
         if (this._path_trailing_slash) path = path + '/';
         return path;


### PR DESCRIPTION
I think this was a typo, fixes #5 

I have not done a rebuild.